### PR TITLE
Add branch name to params

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Name it explicitely, for example SSH_PRIVATE_KEY and copy the private key conten
 - ssh-private-key : required, you need to set it to the github secret related to your SSH_PRIVATE_KEY
 - app-name: required, name of your scalingo app
 - known-host : optional, default is ssh.osc-fr1.scalingo.com
+- branch-name: optional, default is master
 
 app-name and known_host are used to build the scalingo git repo using
 
@@ -51,4 +52,5 @@ steps:
       ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       app-name: app-name
       known-host: ssh.osc-fr1.scalingo.com
+      branch-name: main
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "host to add to known_hosts file"
     required: true
     default: ssh.osc-fr1.scalingo.com
+  branch-name:
+    description: "branch to deploy"
+    required: false
+    default: master
 
 runs:
   using: "composite"
@@ -28,8 +32,8 @@ runs:
         git config --add --local core.sshCommand 'ssh -i /home/runner/.ssh/id_rsa'
         git remote add production git@${{ inputs.known-host }}:${{ inputs.app-name }}.git
         git fetch --unshallow
-        git push --force production HEAD:master
-        if [ "$(git rev-parse production/master)" != "$(git rev-parse HEAD)" ]; then
+        git push --force production HEAD:{{ inputs.branch-name }}
+        if [ "$(git rev-parse production/{{ inputs.branch-name }})" != "$(git rev-parse HEAD)" ]; then
           echo "Failed to push to Scalingo"
           exit 1
         fi


### PR DESCRIPTION
Add the remote branch name to the action params, so that we can use either `master` (set as default) or `main`, as it is mentionned in [the Scalingo doc](https://doc.scalingo.com/platform/deployment/deploy-with-git)